### PR TITLE
[JetPack] Navigation - Fragment から Activity へ遷移

### DIFF
--- a/Jetpack/Navigation/NavigationSample/activitytransition/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
+    implementation 'com.android.support:support-v4:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/Jetpack/Navigation/NavigationSample/activitytransition/src/main/java/com/github/mag0716/activitytransition/MainActivity.kt
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/src/main/java/com/github/mag0716/activitytransition/MainActivity.kt
@@ -2,6 +2,8 @@ package com.github.mag0716.activitytransition
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import androidx.core.os.bundleOf
+import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
@@ -12,7 +14,9 @@ class MainActivity : AppCompatActivity() {
 
         button.setOnClickListener {
             // global Action を使って遷移を試そうとしたが、そもそも NavController を取得する方法がなさそう
-            startActivity(SecondActivity.newIntent(this, "move from MainActivity"))
+            //startActivity(SecondActivity.newIntent(this, "move from MainActivity"))
+            // NavHostFragment を持っていたら、そこから NavController を取得することはできる
+            container.findNavController().navigate(R.id.action_mainFragment_to_secondActivity, bundleOf(SecondActivity.DATA to "move from MainActivity"))
         }
     }
 }

--- a/Jetpack/Navigation/NavigationSample/activitytransition/src/main/java/com/github/mag0716/activitytransition/MainFragment.kt
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/src/main/java/com/github/mag0716/activitytransition/MainFragment.kt
@@ -1,0 +1,27 @@
+package com.github.mag0716.activitytransition
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
+import kotlinx.android.synthetic.main.fragment_main.*
+
+class MainFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_main, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        button.setOnClickListener {
+            view.findNavController()
+                    .navigate(R.id.action_mainFragment_to_secondActivity,
+                            bundleOf(SecondActivity.DATA to "move from MainFragment"))
+        }
+    }
+}

--- a/Jetpack/Navigation/NavigationSample/activitytransition/src/main/res/layout/fragment_main.xml
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/src/main/res/layout/fragment_main.xml
@@ -4,27 +4,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".MainFragment">
 
     <Button
         android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Button on Activity"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <fragment
-        android:id="@+id/container"
-        android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:defaultNavHost="true"
+        android:text="Button on Fragment"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button"
-        app:navGraph="@navigation/navigation" />
+        app:layout_constraintTop_toTopOf="parent" />
 
 </android.support.constraint.ConstraintLayout>

--- a/Jetpack/Navigation/NavigationSample/activitytransition/src/main/res/navigation/navigation.xml
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/src/main/res/navigation/navigation.xml
@@ -2,7 +2,7 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    app:startDestination="@id/mainActivity">
+    app:startDestination="@id/mainFragment">
 
     <activity
         android:id="@+id/mainActivity"
@@ -16,6 +16,15 @@
         tools:layout="@layout/activity_second">
         <deepLink app:uri="com.github.mag0716/data/{data}" />
     </activity>
+    <fragment
+        android:id="@+id/mainFragment"
+        android:name="com.github.mag0716.activitytransition.MainFragment"
+        android:label="fragment_main"
+        tools:layout="@layout/fragment_main" >
+        <action
+            android:id="@+id/action_mainFragment_to_secondActivity"
+            app:destination="@id/secondActivity" />
+    </fragment>
 
     <!--
     MainActivity -> SecondActivity の遷移に利用しようとしたが、Activity から NavController を取得する方法がないっぽい

--- a/Jetpack/Navigation/NavigationSample/activitytransition/src/main/res/values/strings.xml
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">ActivityTransition</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>

--- a/Jetpack/Navigation/README.md
+++ b/Jetpack/Navigation/README.md
@@ -187,6 +187,8 @@ https://developer.android.com/topic/libraries/architecture/navigation/navigation
   * Destination が Activity だと、arguments と deep link しか定義できない
   * Global Action は定義できるが、Activity から NavController を取得する方法がなさそうなので、Activity 間の遷移には利用できない
   * deep link での遷移には利用できるが、Fragment のように Arguments から placeholder で指定した key で文字列を取得することはできない
+  * Fragment -> Activity の遷移には Action を利用できる
+    * NavHostFragment から NavController を取得し、Action が定義されている Fragment を表示中であれば、該当の Action が Fragment からでも利用できる
 * Destination は arguments か action を 1つ以上定義するか、他の Destination で利用されている必要がある
   * ` Destination with arguments or action mush have either name either id attributes`
     * [はまった] navigation タグに id を指定する必要がある(https://issuetracker.google.com/issues/79627172)


### PR DESCRIPTION
## 概要

#2 で試したところ Activity -> Activity への遷移には利用できなかった。
Fragment -> Activity へ遷移できるかを試した。

* Fragment から Activity への Action の追加、遷移は可能
* Actvity でも NavHostFragment からであれば NavController を取得することができる