### PR TITLE
[Navigation] 1.0.0-alpha04

### DIFF
--- a/Jetpack/Navigation/NavigationSample/app/src/main/res/navigation/child_navigation_graph.xml
+++ b/Jetpack/Navigation/NavigationSample/app/src/main/res/navigation/child_navigation_graph.xml
@@ -12,7 +12,7 @@
         <argument
             android:name="count"
             android:defaultValue="0"
-            app:type="integer" />
+            app:argType="integer" />
         <action
             android:id="@+id/action_child"
             app:destination="@id/childFragment" />
@@ -24,7 +24,7 @@
         <argument
             android:name="count"
             android:defaultValue="0"
-            app:type="integer" />
+            app:argType="integer" />
         <action
             android:id="@+id/action_child"
             app:destination="@id/childFragment" />

--- a/Jetpack/Navigation/NavigationSample/app/src/main/res/navigation/sample_navigation_graph.xml
+++ b/Jetpack/Navigation/NavigationSample/app/src/main/res/navigation/sample_navigation_graph.xml
@@ -34,7 +34,7 @@
         tools:layout="@layout/activity_settings">
         <argument
             android:name="dummy"
-            app:type="string" />
+            app:argType="string" />
     </activity>
 
 </navigation>

--- a/Jetpack/Navigation/NavigationSample/blankdestination/src/main/res/navigation/navigation.xml
+++ b/Jetpack/Navigation/NavigationSample/blankdestination/src/main/res/navigation/navigation.xml
@@ -11,7 +11,7 @@
         <argument
             android:name="count"
             android:defaultValue="0"
-            app:type="integer" />
+            app:argType="integer" />
         <action
             android:id="@+id/action_count"
             app:destination="@id/countFragment" />
@@ -24,7 +24,7 @@
         <argument
             android:name="count"
             android:defaultValue="0"
-            app:type="integer" />
+            app:argType="integer" />
         <action
             android:id="@+id/action_count"
             app:destination="@id/countFragment" />

--- a/Jetpack/Navigation/NavigationSample/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.2.50'
-    ext.nav_version = "1.0.0-alpha03"
+    ext.nav_version = "1.0.0-alpha04"
     repositories {
         google()
         jcenter()
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0-alpha03"
+        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0-alpha04"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Jetpack/Navigation/NavigationSample/safeargs/src/main/res/navigation/navigation.xml
+++ b/Jetpack/Navigation/NavigationSample/safeargs/src/main/res/navigation/navigation.xml
@@ -23,8 +23,8 @@
         <argument
             android:name="data"
             android:defaultValue="@null"
-            app:nullable="true"
-            app:type="com.github.mag0716.safeargs.Data" />
+            app:argType="com.github.mag0716.safeargs.Data"
+            app:nullable="true" />
     </fragment>
 
 </navigation>

--- a/Jetpack/Navigation/NavigationSample/safeargs/src/main/res/navigation/navigation.xml
+++ b/Jetpack/Navigation/NavigationSample/safeargs/src/main/res/navigation/navigation.xml
@@ -23,8 +23,8 @@
         <argument
             android:name="data"
             android:defaultValue="@null"
-            app:argType="com.github.mag0716.safeargs.Data"
-            app:nullable="true" />
+            app:nullable="true"
+            app:type="com.github.mag0716.safeargs.Data" />
     </fragment>
 
 </navigation>

--- a/Jetpack/Navigation/README.md
+++ b/Jetpack/Navigation/README.md
@@ -4,7 +4,7 @@
 
 ## 対象バージョン
 
-1.0.0-alpha03
+1.0.0-alpha04
 
 ## サンプル
 
@@ -22,11 +22,29 @@
 * Home, Dashboard, Notifications に切り替えで、ParentFragment へ遷移
   * タブ切り替えで、各タブのバックスタックは復帰せず、必ず ParentFragment へ遷移できる
 * ParentFragment は ChildFragment へ遷移できる
-  * ChildFragment のバックキーでアプリが終了する
+  * ChildFragment のバックキーで前画面に遷移する
 * ChildFragment はさらに ChildFragment へ遷移できる
-  * ChildFragment のボタンをタップしても遷移しない
+  * ChildFragment のボタンをタップで、ChildFragment へ遷移するが、タイトル、ボタン名が正しく反映されていない
 
 ## 更新履歴
+
+### 1.0.0-alpha04
+
+#### API / Behavior Changes
+
+* `NavHostFragment` が現在の Fragment を primary Fragment として扱う様になった(https://issuetracker.google.com/issues/111345778)
+  * これで Fragment がネストされていても、バックキーが ChildFragmentManager に伝搬するようになった
+
+#### Safe Args
+
+* [Breaking Change] `app:type` は他のライブラリとコンフリクトしやすいので `app:argType` に変更された(https://issuetracker.google.com/issues/111110548)
+* Android Studio に表示される Safe Args Plugin のエラーメッセージがクリック可能になった(https://issuetracker.google.com/issues/111534438)
+* NonNull な引数に null を代入可能だった(https://issuetracker.google.com/issues/111451769)
+* Safe Args Plugin で生成されるメソッドに `@NonNull` が指定されるようになった(https://issuetracker.google.com/issues/111455456)
+
+#### Bug Fixes
+
+* Deep Link からの起動で、バックキーで Toolbar が更新されない不具合(https://issuetracker.google.com/issues/111515685)
 
 ### 1.0.0-alpha03
 


### PR DESCRIPTION
## 概要

* https://developer.android.com/jetpack/docs/release-notes#july_19_2018

## CHANGELOG

### API / Behavior Changes

* `NavHostFragment` が現在の Fragment を primary Fragment として扱う様になった(https://issuetracker.google.com/issues/111345778)
  * これで Fragment がネストされていても、バックキーが ChildFragmentManager に伝搬するようになった

### Safe Args

* [Breaking Change] `app:type` は他のライブラリとコンフリクトしやすいので `app:argType` に変更された(https://issuetracker.google.com/issues/111110548)
* Android Studio に表示される Safe Args Plugin のエラーメッセージがクリック可能になった(https://issuetracker.google.com/issues/111534438)
* NonNull な引数に null を代入可能だった(https://issuetracker.google.com/issues/111451769)
* Safe Args Plugin で生成されるメソッドに `@NonNull` が指定されるようになった(https://issuetracker.google.com/issues/111455456)

### Bug Fixes

* Deep Link からの起動で、バックキーで Toolbar が更新されない不具合(https://issuetracker.google.com/issues/111515685)