### PR TITLE
[WorkManager] 1.0.0-alpha05 へアップデート

### DIFF
--- a/Jetpack/WorkManager/WorkManagerSample/build.gradle
+++ b/Jetpack/WorkManager/WorkManagerSample/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.2.50'
-    ext.workmanager_version = '1.0.0-alpha04'
+    ext.workmanager_version = '1.0.0-alpha05'
     repositories {
         google()
         jcenter()

--- a/Jetpack/WorkManager/WorkManagerSample/common/src/main/java/com/github/mag0716/common/LoggingWorker.kt
+++ b/Jetpack/WorkManager/WorkManagerSample/common/src/main/java/com/github/mag0716/common/LoggingWorker.kt
@@ -1,19 +1,18 @@
 package com.github.mag0716.common
 
 import android.util.Log
-import androidx.work.Data
 import androidx.work.Worker
 import androidx.work.toWorkData
 
 class LoggingWorker : Worker() {
 
     companion object {
-        private val KEY = "Tag"
+        private const val KEY = "Tag"
         fun createInputData(tag: String) = mapOf(KEY to tag).toWorkData()
     }
 
     override fun doWork(): Result {
-        val tag = inputData.getString(KEY, "WorkManagerSample")
+        val tag = inputData.getString(KEY)
         Log.d(tag, "doWork start...")
         Thread.sleep(3000)
         Log.d(tag, "doWork finish!!")

--- a/Jetpack/WorkManager/WorkManagerSample/onetime/src/main/java/com/github/mag0716/workmanagersample/MainActivity.kt
+++ b/Jetpack/WorkManager/WorkManagerSample/onetime/src/main/java/com/github/mag0716/workmanagersample/MainActivity.kt
@@ -27,10 +27,10 @@ class MainActivity : AppCompatActivity() {
                 .setInputData(LoggingWorker.createInputData(TAG))
                 .build()
         // ENQUEUED -> RUNNING -> SUCCEEDED の順だが、ENQUEUED が出力されない場合もある
-        WorkManager.getInstance()!!.getStatusById(work.id)
+        WorkManager.getInstance().getStatusById(work.id)
                 .observe(this, Observer { status ->
                     Log.d(TAG, "observe : status = $status")
                 })
-        WorkManager.getInstance()!!.enqueue(work)
+        WorkManager.getInstance().enqueue(work)
     }
 }

--- a/Jetpack/WorkManager/WorkManagerSample/periodic/src/main/java/com/github/mag0716/periodic/MainActivity.kt
+++ b/Jetpack/WorkManager/WorkManagerSample/periodic/src/main/java/com/github/mag0716/periodic/MainActivity.kt
@@ -27,10 +27,10 @@ class MainActivity : AppCompatActivity() {
         val work = PeriodicWorkRequestBuilder<LoggingWorker>(1L, TimeUnit.MINUTES)
                 .setInputData(LoggingWorker.createInputData(TAG))
                 .build()
-        WorkManager.getInstance()!!.getStatusById(work.id)
+        WorkManager.getInstance().getStatusById(work.id)
                 .observe(this, Observer { status ->
                     Log.d(TAG, "observe : status = $status")
                 })
-        WorkManager.getInstance()!!.enqueue(work)
+        WorkManager.getInstance().enqueue(work)
     }
 }


### PR DESCRIPTION
## 概要

* https://developer.android.com/jetpack/docs/release-notes#july_24_2018

## CHANGELOG

### API Changes

* [Breaking Changes] `WorkManager.getInstance()` も戻り値が `@NonNull` に変更
* `Configuration.Builder.setMinimumLogginLevel` が追加され、ログレベルが変更できる様になった
  * デフォルトは、`Log.INFO`
* [Breaking Changes] `Data#getString()` でデフォルト値が指定できなくなり、デフォルト値は null 固定になった
* [Breaking Changes] `Data#toByteArray`, `Data#fromByteArray` がライブラリからの呼び出しに制限された

### Bug Fixes

* 自動アップデート後のクラッシュ(https://issuetracker.google.com/issues/110564377)
* `JobScheduler` が使われた場合に、`PeriodicWorkRequest` が2重でスケジューリングされる(https://issuetracker.google.com/issues/110798652)
* Doze 後に `PeriodicWorkRequest` が正常に実行されない(https://issuetracker.google.com/issues/111469837)
* Firebase JobDispatcher を `setInitialDelay` と一緒に利用されると実行されない(https://issuetracker.google.com/issues/111141023)
* 競合状態とタイミングの不具合を修正
    * Issue Tracker のリンクがないため詳細が不明
* 不要な BroadcastReceiver が解放されるようになった
* 強制終了後の再起動後の再スケジュールのパフォーマンスが最適化された
* `WorkRequest` のエンキュー前後に `TestScheduler.setAllConstraintMet` が呼べる様になった(https://issuetracker.google.com/issues/111238024)
