### PR TITLE
[Navigation] 1.0.0-alpha06

### DIFF
--- a/Jetpack/Navigation/NavigationSample/app/src/main/java/com/github/mag0716/navigationsample/MainActivity.kt
+++ b/Jetpack/Navigation/NavigationSample/app/src/main/java/com/github/mag0716/navigationsample/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : AppCompatActivity(), NavController.OnNavigatedListener {
         // BottomNavigationView に渡す menu に指定する id は Navigation Graph の destination の id と同じにする必要がある
         NavigationUI.setupWithNavController(bottomNavigation, container.navController)
 
-        Log.d(TAG, "onCreate : ${container.navController.currentDestination.label}")
+        Log.d(TAG, "onCreate : ${container.navController.currentDestination?.label}")
     }
 
     override fun onResume() {

--- a/Jetpack/Navigation/NavigationSample/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.2.50'
-    ext.nav_version = "1.0.0-alpha04"
+    ext.nav_version = "1.0.0-alpha06"
     repositories {
         google()
         jcenter()
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0-alpha04"
+        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0-alpha06"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Jetpack/Navigation/NavigationSample/safeargs/src/main/res/navigation/navigation.xml
+++ b/Jetpack/Navigation/NavigationSample/safeargs/src/main/res/navigation/navigation.xml
@@ -23,8 +23,8 @@
         <argument
             android:name="data"
             android:defaultValue="@null"
-            app:nullable="true"
-            app:type="com.github.mag0716.safeargs.Data" />
+            app:argType="com.github.mag0716.safeargs.Data"
+            app:nullable="true" />
     </fragment>
 
 </navigation>

--- a/Jetpack/Navigation/README.md
+++ b/Jetpack/Navigation/README.md
@@ -30,6 +30,45 @@
 
 ## 更新履歴
 
+### 1.0.0-alpha06
+
+* https://developer.android.com/jetpack/docs/release-notes#september_20_2018
+
+#### New Features
+
+* Shared Element Transitions に対応(https://developer.android.com/topic/libraries/architecture/navigation/navigation-implementing#shared-element)
+  * `FragmentNavigator.Extras`
+  * `ActivityNavigator.Extras`
+* BottomSheetDialogFragment に対応(https://issuetracker.google.com/issues/112158843)
+
+#### API Changes
+
+* [Breaking Change] navigate にパラメータが追加
+* `getGraph` が `NonNull` になった
+
+#### Bug Fixes
+
+* `NavigationUI.setupWithNavController` のリーク(https://issuetracker.google.com/issues/111961977)
+* `onSaveState` が複数回呼ばれていた不具合が修正(https://issuetracker.google.com/issues/112627079)
+
+#### Safe Args
+
+* Navigation が親の Navigation を継承するようになった(https://issuetracker.google.com/issues/79871405)
+* `toString` が実装された(https://issuetracker.google.com/issues/111843389)
+
+### 1.0.0-alpha05
+
+* https://developer.android.com/jetpack/docs/release-notes#august_10_2018
+
+#### Bug Fixes
+
+* バックキー遷移でバックスタックが不正になる(https://issuetracker.google.com/issues/111907708)
+* Args の equals が不正(https://issuetracker.google.com/issues/111450897)
+* git でブランチの切り替えをするとSafe Args でのビルドに失敗する(https://issuetracker.google.com/issues/109409713)
+* ドットが含まれた ID だと Safe Args のビルドに失敗する(https://issuetracker.google.com/issues/111602491)
+* Safe Args の nullability に関するエラーメッセージが変更
+* `@Nullable` が正しく追加されるようになる
+
 ### 1.0.0-alpha04
 
 #### API / Behavior Changes

--- a/Jetpack/Navigation/README.md
+++ b/Jetpack/Navigation/README.md
@@ -4,26 +4,28 @@
 
 ## 対象バージョン
 
-1.0.0-alpha04
+1.0.0-alpha06
 
 ## サンプル
 
 | モジュール名 | 概要 | 作成バージョン |
 | --- | --- | --- |
 | app | デフォルト動作でない使い方のサンプルで不正な挙動となっている(#6) | 1.0.0-alpha02 |
-| blankdestination | startDestination にレイアウトのない Fragment を利用した(#8) | 1.0.0-alpha02 |
-| bottomnavigation | 通常の BottomNavigationView の動作(#12) | 1.0.0-alpha02 |
-| nestednavigation | conditional navigation の動作\nProfile 画面で未ログインだったら Login 画面へ遷移する。(#5) | 1.0.0-alpha02 |
+| blankdestination | startDestination にレイアウトのない Fragment を利用した(#8)<br/>スプラッシュを想定 | 1.0.0-alpha02 |
+| bottomnavigation | 通常の BottomNavigationView の動作(#12)<br/>replaceし直されるので、EditText の内容は復帰しない | 1.0.0-alpha02 |
+| nestednavigation | conditional navigation の動作<br/>Profile 画面で未ログインだったら Login 画面へ遷移する。(#5) | 1.0.0-alpha02 |
 | toolbar | Toolbar 単体で利用する Activity のサンプル | 1.0.0-alpha03 |
 | safeargs | Safe Args Plugin のサンプル | 1.0.0-alpha03 |
 
 ### app
 
 * Home, Dashboard, Notifications に切り替えで、ParentFragment へ遷移
-  * タブ切り替えで、各タブのバックスタックは復帰せず、必ず ParentFragment へ遷移できる
-* ParentFragment は ChildFragment へ遷移できる
+  * タブ切り替えで、各タブのバックスタックは復帰せず、必ず ParentFragment へ遷移する
+  * ただし、バックキーを使う場合は、バックスタックも保持した状態でタブの切り替えが行われる
+    * TODO: 1.0.0-alpha06で動作が変わったのかを確認する
+* ParentFragment は ChildFragment へ遷移する
   * ChildFragment のバックキーで前画面に遷移する
-* ChildFragment はさらに ChildFragment へ遷移できる
+* ChildFragment はさらに ChildFragment へ遷移する
   * ChildFragment のボタンをタップで、ChildFragment へ遷移するが、タイトル、ボタン名が正しく反映されていない
 
 ## 更新履歴


### PR DESCRIPTION
## 1.0.0-alpha06

* https://developer.android.com/jetpack/docs/release-notes#september_20_2018

### New Features

* Shared Element Transitions に対応(https://developer.android.com/topic/libraries/architecture/navigation/navigation-implementing#shared-element)
  * `FragmentNavigator.Extras`
  * `ActivityNavigator.Extras`
* BottomSheetDialogFragment に対応(https://issuetracker.google.com/issues/112158843)

### API Changes

* [Breaking Change] navigate にパラメータが追加
* `getGraph` が `NonNull` になった

### Bug Fixes

* `NavigationUI.setupWithNavController` のリーク(https://issuetracker.google.com/issues/111961977)
* `onSaveState` が複数回呼ばれていた不具合が修正(https://issuetracker.google.com/issues/112627079)

### Safe Args

* Navigation が親の Navigation を継承するようになった(https://issuetracker.google.com/issues/79871405)
* `toString` が実装された(https://issuetracker.google.com/issues/111843389)

## 1.0.0-alpha05

* https://developer.android.com/jetpack/docs/release-notes#august_10_2018

#### Bug Fixes

* バックキー遷移でバックスタックが不正になる(https://issuetracker.google.com/issues/111907708)
* Args の equals が不正(https://issuetracker.google.com/issues/111450897)
* git でブランチの切り替えをするとSafe Args でのビルドに失敗する(https://issuetracker.google.com/issues/109409713)
* ドットが含まれた ID だと Safe Args のビルドに失敗する(https://issuetracker.google.com/issues/111602491)
* Safe Args の nullability に関するエラーメッセージが変更
* `@Nullable` が正しく追加されるようになる