### PR TITLE
Android Studio を 3.3-beta2 にアップデート

### DIFF
--- a/Jetpack/Navigation/NavigationSample/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha12'
+        classpath 'com.android.tools.build:gradle:3.3.0-beta02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 


### PR DESCRIPTION
## 概要

#52 対応前に、Android Studio をアップデートする

## 参考

https://androidstudio.googleblog.com/2018/10/android-studio-33-beta-2-is-available.html

