### PR TITLE
Android Studio を 3.4 Canary 10 に更新

### DIFF
--- a/Jetpack/Navigation/NavigationSample/activitytransition/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/app/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/appbarconfiguration/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/appbarconfiguration/build.gradle
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/blankdestination/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/blankdestination/build.gradle
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/bottomnavigation/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/bottomnavigation/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/bottomsheetdialog/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/bottomsheetdialog/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-rc03'
+        classpath 'com.android.tools.build:gradle:3.4.0-alpha10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/Jetpack/Navigation/NavigationSample/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.11'
     ext.appcompat_version = '1.0.0'
     ext.constraint_layout_version = '1.1.3'
     ext.ktx_version = '1.0.0'
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-beta02'
+        classpath 'com.android.tools.build:gradle:3.3.0-rc03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/Jetpack/Navigation/NavigationSample/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetpack/Navigation/NavigationSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 29 23:29:11 JST 2018
+#Tue Jan 08 23:04:45 JST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-milestone-1-all.zip

--- a/Jetpack/Navigation/NavigationSample/nestednavigation/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/nestednavigation/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/safeargs/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/safeargs/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/sharedelementtransition/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/sharedelementtransition/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 

--- a/Jetpack/Navigation/NavigationSample/toolbar/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/toolbar/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 


### PR DESCRIPTION
Navigation 1.0.0-alpha09 で SafeArgs を使うには Android Gradle Plugin 3.4 Canary 4 以上が必要になったので、3.4 の最新に更新