### PR TITLE
Navigation を 2.0.0-rc02 にアップデート

### DIFF
--- a/Jetpack/Navigation/NavigationSample/activitytransition/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/activitytransition/build.gradle
@@ -33,10 +33,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/app/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/app/build.gradle
@@ -28,10 +28,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/appbarconfiguration/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/appbarconfiguration/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/blankdestination/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/blankdestination/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/bottomnavigation/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/bottomnavigation/build.gradle
@@ -30,10 +30,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/bottomsheetdialog/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/bottomsheetdialog/build.gradle
@@ -30,10 +30,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/build.gradle
@@ -5,15 +5,15 @@ buildscript {
     ext.appcompat_version = '1.0.0'
     ext.constraint_layout_version = '1.1.3'
     ext.ktx_version = '1.0.0'
-    ext.nav_version = '1.0.0-alpha09'
+    ext.nav_version = '2.0.0-rc02'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-alpha10'
+        classpath 'com.android.tools.build:gradle:3.4.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$nav_version"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Jetpack/Navigation/NavigationSample/gradle/wrapper/gradle-wrapper.properties
+++ b/Jetpack/Navigation/NavigationSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/Jetpack/Navigation/NavigationSample/nestednavigation/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/nestednavigation/build.gradle
@@ -32,10 +32,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/onnavigateuplistener/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/onnavigateuplistener/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/safeargs/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/safeargs/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/sharedelementtransition/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/sharedelementtransition/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'

--- a/Jetpack/Navigation/NavigationSample/toolbar/build.gradle
+++ b/Jetpack/Navigation/NavigationSample/toolbar/build.gradle
@@ -5,7 +5,6 @@ android {
     compileSdkVersion 28
 
 
-
     defaultConfig {
         applicationId "com.github.mag0716.toolbar"
         minSdkVersion 21
@@ -33,10 +32,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
     implementation "androidx.core:core-ktx:$ktx_version"
-    implementation "android.arch.navigation:navigation-fragment:$nav_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "android.arch.navigation:navigation-ui:$nav_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-fragment:$nav_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // for test
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
## 概要

#13 対応するために先に Navigation を最新にしておく。
差分チェックや各モジュールの動作確認は #67 で実施する。