### PR TITLE
[in-app updates] flexible

### DIFF
--- a/App Bundle/app/build.gradle
+++ b/App Bundle/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.github.mag0716.appbundlessample"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 29
-        versionName "1.3.4"
+        versionCode 30
+        versionName "1.4.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -27,6 +27,7 @@ dependencies {
     api 'androidx.appcompat:appcompat:1.0.2'
     api 'androidx.constraintlayout:constraintlayout:1.1.3'
     api "com.google.android.play:core:1.5.0"
+    implementation "com.google.android.material:material:1.0.0"
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/App Bundle/app/build.gradle
+++ b/App Bundle/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.github.mag0716.appbundlessample"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 32
-        versionName "1.4.2"
+        versionCode 33
+        versionName "1.4.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/App Bundle/app/build.gradle
+++ b/App Bundle/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.github.mag0716.appbundlessample"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 30
-        versionName "1.4.0"
+        versionCode 31
+        versionName "1.4.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/App Bundle/app/build.gradle
+++ b/App Bundle/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.github.mag0716.appbundlessample"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 31
-        versionName "1.4.1"
+        versionCode 32
+        versionName "1.4.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/App Bundle/app/src/main/java/com/github/mag0716/appbundlessample/MainActivity.kt
+++ b/App Bundle/app/src/main/java/com/github/mag0716/appbundlessample/MainActivity.kt
@@ -57,6 +57,7 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
     }
 
     private var appUpdateInfo: AppUpdateInfo? = null
+    private var preUpdateType: Int? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -95,6 +96,7 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
 
     override fun onResume() {
         super.onResume()
+        logWithText("onResume : $preUpdateType")
         appUpdateManager.registerListener(installStateUpdatedListener)
         appUpdateManager.appUpdateInfo
                 .addOnSuccessListener { appUpdateInfo ->
@@ -113,13 +115,16 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
                                 flexibleUpdatesButton.isEnabled = true
                             }
                         } else if (updateAvailability == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
-                            // アプリ更新中なので再開する
-                            appUpdateManager.startUpdateFlowForResult(
-                                    appUpdateInfo,
-                                    AppUpdateType.IMMEDIATE,
-                                    this,
-                                    REQUEST_IMMEDIATE_UPDATES
-                            )
+                            // Flexible のダイアログを閉じたあとにここに入ってしまうのでチェック
+                            if (preUpdateType == AppUpdateType.IMMEDIATE) {
+                                // アプリ更新中なので再開する
+                                appUpdateManager.startUpdateFlowForResult(
+                                        appUpdateInfo,
+                                        AppUpdateType.IMMEDIATE,
+                                        this,
+                                        REQUEST_IMMEDIATE_UPDATES
+                                )
+                            }
                         }
                     }
                 }
@@ -200,6 +205,7 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
     }
 
     private fun requestImmediateUpdatesIfNeeded() {
+        preUpdateType = AppUpdateType.IMMEDIATE
         appUpdateManager.startUpdateFlowForResult(
                 appUpdateInfo,
                 AppUpdateType.IMMEDIATE,
@@ -211,6 +217,7 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
     }
 
     private fun requestFlexibleUpdatesIfNeeded() {
+        preUpdateType = AppUpdateType.FLEXIBLE
         appUpdateManager.startUpdateFlowForResult(
                 appUpdateInfo,
                 AppUpdateType.FLEXIBLE,

--- a/App Bundle/app/src/main/java/com/github/mag0716/appbundlessample/MainActivity.kt
+++ b/App Bundle/app/src/main/java/com/github/mag0716/appbundlessample/MainActivity.kt
@@ -9,11 +9,13 @@ import android.widget.Button
 import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
 import com.google.android.play.core.splitinstall.*
 import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus
@@ -32,9 +34,11 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
     companion object {
         const val TAG = "DynamicFeature"
         private const val REQUEST_IMMEDIATE_UPDATES = 100
+        private const val REQUEST_FLEXIBLE_UPDATES = 200
     }
 
     private lateinit var immediateUpdatesButton: Button
+    private lateinit var flexibleUpdatesButton: Button
     private lateinit var independentModuleButton: Button
     private lateinit var dependencyModuleButton: Button
     private lateinit var textView: TextView
@@ -45,7 +49,12 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
     private lateinit var appUpdateManager: AppUpdateManager
     private lateinit var manager: SplitInstallManager
 
-    private val installStateUpdatedListener = InstallStateUpdatedListener { state -> logWithText("install State : $state") }
+    private val installStateUpdatedListener = InstallStateUpdatedListener { state ->
+        logWithText("install State : $state")
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            popupSnackbarForCompleteUpdate()
+        }
+    }
 
     private var appUpdateInfo: AppUpdateInfo? = null
 
@@ -59,6 +68,10 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
         immediateUpdatesButton = findViewById(R.id.immediate_updates_button)
         immediateUpdatesButton.setOnClickListener {
             requestImmediateUpdatesIfNeeded()
+        }
+        flexibleUpdatesButton = findViewById(R.id.flexible_updates_button)
+        flexibleUpdatesButton.setOnClickListener {
+            requestFlexibleUpdatesIfNeeded()
         }
         independentModuleButton = findViewById(R.id.independent_dynamic_feature_button)
         independentModuleButton.setOnClickListener {
@@ -86,20 +99,28 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
         appUpdateManager.appUpdateInfo
                 .addOnSuccessListener { appUpdateInfo ->
                     logWithText("in-app updates success : ${appUpdateInfo.toStringForLog()}")
-                    val updateAvailability = appUpdateInfo.updateAvailability()
-                    if (updateAvailability == UpdateAvailability.UPDATE_AVAILABLE) {
-                        this.appUpdateInfo = appUpdateInfo
-                        if (appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
-                            immediateUpdatesButton.isEnabled = true
+                    if (appUpdateInfo.installStatus() == InstallStatus.DOWNLOADED) {
+                        // Immediate は自動的に再起動が行われるのでここには到達しない
+                        popupSnackbarForCompleteUpdate()
+                    } else {
+                        val updateAvailability = appUpdateInfo.updateAvailability()
+                        if (updateAvailability == UpdateAvailability.UPDATE_AVAILABLE) {
+                            this.appUpdateInfo = appUpdateInfo
+                            if (appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
+                                immediateUpdatesButton.isEnabled = true
+                            }
+                            if (appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
+                                flexibleUpdatesButton.isEnabled = true
+                            }
+                        } else if (updateAvailability == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
+                            // アプリ更新中なので再開する
+                            appUpdateManager.startUpdateFlowForResult(
+                                    appUpdateInfo,
+                                    AppUpdateType.IMMEDIATE,
+                                    this,
+                                    REQUEST_IMMEDIATE_UPDATES
+                            )
                         }
-                    } else if (updateAvailability == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
-                        // アプリ更新中なので再開する
-                        appUpdateManager.startUpdateFlowForResult(
-                                appUpdateInfo,
-                                AppUpdateType.IMMEDIATE,
-                                this,
-                                REQUEST_IMMEDIATE_UPDATES
-                        )
                     }
                 }
                 .addOnFailureListener {
@@ -187,6 +208,27 @@ class MainActivity : AppCompatActivity(), SplitInstallStateUpdatedListener, Adap
         )
         // 擬似強制アップデート
         finish()
+    }
+
+    private fun requestFlexibleUpdatesIfNeeded() {
+        appUpdateManager.startUpdateFlowForResult(
+                appUpdateInfo,
+                AppUpdateType.FLEXIBLE,
+                this,
+                REQUEST_FLEXIBLE_UPDATES
+        )
+    }
+
+    private fun popupSnackbarForCompleteUpdate() {
+        Snackbar.make(
+                findViewById(R.id.container),
+                "in-app updates",
+                Snackbar.LENGTH_INDEFINITE
+        ).apply {
+            setAction("更新") {
+                appUpdateManager.completeUpdate()
+            }
+        }.show()
     }
 
     private fun launchFeatureModule(moduleName: String) {

--- a/App Bundle/app/src/main/res/layout/activity_main.xml
+++ b/App Bundle/app/src/main/res/layout/activity_main.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
@@ -13,8 +14,19 @@
         android:enabled="false"
         android:text="Immediate Updates"
         app:layout_constraintBottom_toTopOf="@id/scroll_view"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/flexible_updates_button"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/flexible_updates_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="Flexible Updates"
+        app:layout_constraintBottom_toTopOf="@id/scroll_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/immediate_updates_button"
         app:layout_constraintTop_toTopOf="parent" />
 
     <ScrollView


### PR DESCRIPTION
## 概要

in-app updates の flexible を試す

## 関連

https://github.com/mag0716/Google_IO_2019_CatchUp/issues/12

## 準正常系、異常系動作確認項目

### Immediate

- [x] ダウンロード中に停止
    * アプリが終了する(前画面に戻る)、次回起動後のダウンロード再開ができない
    * updateAvailability は UPDATE_AVAILABLE なので、startUpdateFlowForResult は呼び出されるが更新画面に遷移しない
- [x] ダウンロード中に BG
    * 次回起動時に既に更新されている(1度起動に失敗する)
- [x] ダウンロード中にアプリ終了
    * 次回起動時に既に更新されている
- [x] インストール中に BG
    * 次回起動時に既に更新されている(1度起動に失敗する)
- [x] インストール中にアプリ終了
    * 次回起動時に既に更新されている(1度起動に失敗する)
- [x] ネットワーク未接続で更新ボタンをタップ
    * Wi-Fi 接続待ちになる
    * アプリが終了しても Wi-Fi が接続されれば自動的にダウンロードされる
- [x] ダウンロード中にネットワーク切断
    * Wi-Fi 接続待ちになる
    * アプリが終了しても Wi-Fi が接続されれば自動的にダウンロードされる

### Flexible

- [x] ダイアログ表示中に BG
    * ダイアログは表示されたまま
- [x] ダウンロード中に BG
    * 次回起動時に既に更新されている
- [x] ダウンロード中にアプリ終了
    * 次回起動時に既に更新されている
- [x] ダウンロード完了後に更新せずにアプリ終了
    * ハンドリングしているので更新用の Snackbar が表示される
- [x] インストール中に BG
    * 次回起動時に更新されている
- [x] インストール中にアプリ終了
    * 次回起動時に更新されている
- [x] ネットワーク未接続で更新ボタンをタップ
    * インジケータは何も表示されないが Wi-Fi 接続待ちになる
    * アプリが終了しても Wi-Fi が接続されれば自動的にダウンロードされる
- [x] ダウンロード中にネットワーク切断
    * インジケータは何も表示されないが Wi-Fi 接続待ちになる
    * アプリが終了しても Wi-Fi が接続されれば自動的にダウンロードされる